### PR TITLE
Modify our skills to write results to tmp dir

### DIFF
--- a/skills/parallel-web-extract/SKILL.md
+++ b/skills/parallel-web-extract/SKILL.md
@@ -17,8 +17,10 @@ Extract content from: $ARGUMENTS
 
 ## Command
 
+Choose a short, descriptive filename based on the URL or content (e.g., `vespa-docs`, `react-hooks-api`). Use lowercase with hyphens, no spaces.
+
 ```bash
-parallel-cli extract "$ARGUMENTS" --json
+parallel-cli extract "$ARGUMENTS" --json -o "/tmp/$FILENAME.md"
 ```
 
 Options if needed:
@@ -35,6 +37,8 @@ Then the extracted content verbatim, with these rules:
 - Parse lists exhaustively - extract EVERY numbered/bulleted item
 - Strip only obvious noise: nav menus, footers, ads
 - Preserve all facts, names, numbers, dates, quotes
+
+After the response, mention the output file path (`/tmp/$FILENAME.md`) so the user knows it's available for follow-up questions.
 
 ## Setup
 

--- a/skills/parallel-web-search/SKILL.md
+++ b/skills/parallel-web-search/SKILL.md
@@ -20,7 +20,7 @@ Search the web for: $ARGUMENTS
 Choose a short, descriptive filename based on the query (e.g., `ai-chip-news`, `react-vs-vue`). Use lowercase with hyphens, no spaces.
 
 ```bash
-parallel-cli search "$ARGUMENTS" -q "<keyword1>" -q "<keyword2>" --json --max-results 10 --excerpt-max-chars-total 27000 -o "$FILENAME.json"
+parallel-cli search "$ARGUMENTS" -q "<keyword1>" -q "<keyword2>" --json --max-results 10 --excerpt-max-chars-total 27000 -o "/tmp/$FILENAME.json"
 ```
 
 The first argument is the **objective** — a natural language description of what you're looking for. It replaces multiple keyword searches with a single call for broad or complex queries. Add `-q` flags for specific keyword queries to supplement the objective. The `-o` flag saves the full results to a JSON file for follow-up questions.
@@ -55,7 +55,7 @@ Sources:
 
 This Sources section is mandatory. Do not omit it.
 
-After the Sources section, mention the output file path (`$FILENAME.json`) so the user knows it's available for follow-up questions.
+After the Sources section, mention the output file path (`/tmp/$FILENAME.json`) so the user knows it's available for follow-up questions.
 
 ## Setup
 


### PR DESCRIPTION
WHAT:
1. Make parallel-search write to a temp file instead of to the current workspace
2. Make parallel-extract consistent with parallel-search, writing to a temp file for later reading if needed.

WHY:
1. The current behavior writes to a persisted file in the current working directory, polluting the workspace and making the skill less friendly.
2. Makes the behavior uniform. Should be no downside to this, right?