### PR TITLE
Add turbo mode to parallel-web-search skill

### DIFF
--- a/skills/parallel-cli-setup/SKILL.md
+++ b/skills/parallel-cli-setup/SKILL.md
@@ -26,7 +26,7 @@ If missing, install with any of these methods:
 3. Linux/macOS/Windows (npm): `npm install -g parallel-web-cli`
 4. Linux/macOS/Windows (pipx): `pipx install "parallel-web-tools[cli]" && pipx ensurepath`
 
-When `parallel-cli` is present, require version `>=0.4.0`. If older, identify the install method before advising an update. Use `command -v parallel-cli`, then inspect `readlink "$(command -v parallel-cli)"` if it is a symlink. Paths under `~/.local/share/uv/
+When `parallel-cli` is present, require version `>=0.7.1`. If older, identify the install method before advising an update. Use `command -v parallel-cli`, then inspect `readlink "$(command -v parallel-cli)"` if it is a symlink. Paths under `~/.local/share/uv/
   tools/` indicate `uv tool install`; paths under `~/.local/share/parallel-cli/` indicate the standalone installer.
 
 Upgrade commands (choose based on how it was installed):

--- a/skills/parallel-web-search/SKILL.md
+++ b/skills/parallel-web-search/SKILL.md
@@ -36,7 +36,8 @@ Options if needed:
 - `--after-date YYYY-MM-DD` for time-sensitive queries
 - `--include-domains domain1.com,domain2.com` to limit to specific sources
 - `--exclude-domains domain.com` to filter out noisy sources
-- `--mode advanced` for harder questions (multi-step, agentic search). Default `basic` is right for almost everything; only escalate when basic results are insufficient
+- `--mode turbo` for simple fact lookups where speed and cost matter most (p50 ~200ms, lowest cost). English and Japanese queries only
+- `--mode advanced` for harder questions (multi-step, agentic search). Default `basic` is right for almost everything; escalate to `advanced` only when basic results are insufficient, and drop to `turbo` for high-volume simple lookups
 - `--location us` (ISO 3166-1 alpha-2) for geo-targeted results
 
 ## Parsing results


### PR DESCRIPTION
## Summary

Adds `--mode turbo` to the `parallel-web-search` skill's options list, ahead of the Turbo launch (July 13).

The CLI already fully supports `--mode turbo` (see `parallel-web-tools`, `_SEARCH_MODE_MAP`), so nothing is mechanically blocked. But the skill is the recipe agents actually follow, and it never mentions turbo. Its current guidance ("default `basic` is right for almost everything") means skill-driven searches would never use the fastest, lowest-cost mode.

## Changes

- One bullet added for `--mode turbo` (simple fact lookups, p50 ~200ms, lowest cost, EN/JA only)
- The `--mode advanced` bullet's escalation guidance extended so the three modes read as one spectrum

## Also included

- CLI version floor in `parallel-cli-setup` bumped `>=0.4.0` to `>=0.7.1`, carried over from #40 per @zhengchaol so the setup skill guarantees a turbo-capable CLI.

## Notes

- Prose-only change to `skills/parallel-web-search/SKILL.md`; no code, no manifests touched
- Existing installs pick this up when users re-run skill install; the live catalog at skills.parallel.ai updates on merge to main
- The EN/JA language caveat is intentional so agents don't route multilingual queries to turbo

@zhengchaol @sergei1152 tagging you as the active maintainers. This pairs with the Turbo docs PR (shapleyai/documentation#640) and the langchain-parallel turbo PR (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


