### PR TITLE
Fix parallel-monitor for GA Monitor CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install released Parallel CLI
-        run: python3 -m pip install parallel-web-tools
+        run: python3 -m pip install --upgrade parallel-web-tools
 
       - name: Install pre-commit
         run: python3 -m pip install pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,16 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install released Parallel CLI
+        run: python3 -m pip install parallel-web-tools
+
       - name: Install pre-commit
         run: python3 -m pip install pre-commit
 
       - name: Run pre-commit
         run: pre-commit run --all-files
 
-      - name: Run scanner tests
+      - name: Run Python tests
         run: python3 -m unittest discover -s tests
 
       - name: Validate CDN site build

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-monitor
-description: "Continuously track the web for changes on a recurring frequency. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, trigger, or cancel existing monitors and retrieve their events."
+description: "Continuously track the web for changes on a recurring cadence. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, or delete existing monitors."
 user-invocable: true
 argument-hint: <create|list|events|get|update|trigger|cancel> [args]
 compatibility: Requires parallel-cli >= 0.4.0 and internet access.
@@ -17,7 +17,7 @@ Action: $ARGUMENTS
 
 ## What this skill does
 
-Monitors are long-running, server-side jobs that check the web on a fixed frequency and emit events when a material change is detected. They persist until cancelled. Recent events are available server-side for polling and can optionally be delivered through a webhook.
+Monitors are long-running, server-side jobs that re-check the web on a cadence and emit events when something changes. Unlike search/research/findall (one-shot lookups), monitors persist until cancelled and can optionally fire a webhook on each event.
 
 ## Decide the action
 
@@ -29,100 +29,72 @@ Parse the user's request and pick one:
 | "What am I monitoring?" / "List monitors" | **list** |
 | "What changed?" / "Show me events for monitor X" | **events** |
 | "Show monitor X" / "Get details for X" | **get** |
-| "Change frequency / webhook / metadata for X" | **update** |
+| "Change cadence / webhook / metadata for X" | **update** |
 | "Check monitor X now" / "Run it now" | **trigger** |
-| "Show the events from execution X" | **events** with `--event-group-id` |
-| "Stop / cancel monitor X" | **cancel** (always confirm first) |
+| "Show me the full payload for event group X" | **events** with `--event-group-id` |
+| "Stop / delete monitor X" | **cancel** (always confirm before cancelling) |
 
 ## Create a monitor
-
-Create an `event_stream` monitor for a natural-language query:
 
 ```bash
 parallel-cli monitor create "<query>" --frequency 1d --json
 ```
 
-Frequency uses `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `6h`, `1d`, or `2w`). The aliases `hourly`, `daily`, `weekly`, and `every_two_weeks` are also accepted. Match the frequency to how often the subject changes.
+Frequency accepts `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `1d`, or `1w`). The aliases `hourly`, `daily`, `weekly`, and `every_two_weeks` are also accepted. Match the cadence to how often the source actually changes — hourly for prices/news, weekly for filings/staffing.
 
-Useful options:
+Optional flags:
 
-- `--processor lite|base` — `lite` is the default; use `base` for harder queries that need greater recall
-- `--webhook https://example.com/hook` — deliver detected events to a webhook
-- `--metadata '{"team":"competitive-intel"}'` — attach bookkeeping metadata
-- `--output-schema '<json>'` — structure `event_stream` event output
-- `--include-backfill` — include a historical sample on the first `event_stream` run
+- `--webhook https://example.com/hook` — POST events to a URL as they happen
+- `--metadata '{"team":"competitive-intel"}'` — attach JSON metadata for your own bookkeeping
+- `--output-schema '<json>'` — structure the event payload (advanced)
 
-To monitor changes to an existing Task Run output, create a `snapshot` monitor without a query:
+Parse the JSON to extract the `monitor_id`. Tell the user:
 
-```bash
-parallel-cli monitor create --type snapshot --task-run-id trun_abc --frequency 1d --json
-```
+- The monitor has been created with its ID
+- The frequency (so they know when to expect first event)
+- That events accumulate server-side — they can run `parallel-cli monitor events $MONITOR_ID` later to see what changed
 
-The monitor runs once immediately when created, then continues on its configured schedule. Parse the JSON to extract the `monitor_id`, and tell the user the ID, type, frequency, and delivery method.
-
-Events can be retrieved without a webhook through `parallel-cli monitor events "$MONITOR_ID" --json`, but the API exposes only a bounded recent history. Poll or persist events downstream when durable history matters.
-
-## List and inspect monitors
+## List monitors
 
 ```bash
-parallel-cli monitor list --limit 10 --json
-parallel-cli monitor get "$MONITOR_ID" --json
+parallel-cli monitor list -n 10 --json
 ```
 
-`list` returns active monitors newest first by default. Use repeated `--status` flags to include both active and cancelled monitors, and use the returned `next_cursor` for another page:
+Default to `-n 10` — accounts with many historical monitors can return megabytes of JSON otherwise. Raise the limit only if the user explicitly asks for "all" or a larger set. Present as a table: ID, query (truncated), frequency, created.
+
+> Note: `monitor list` is sorted newest-first. If a user is verifying creation, prefer `monitor get $MONITOR_ID` (using the ID returned by create) over scanning the list.
+
+## View events for a monitor
 
 ```bash
-parallel-cli monitor list --status active --status cancelled --limit 10 --json
-parallel-cli monitor list --cursor "$NEXT_CURSOR" --limit 10 --json
+parallel-cli monitor events "$MONITOR_ID" --json
 ```
 
-Present monitors as a compact table with ID, type, tracked query or Task Run, frequency, and status. When verifying a newly created monitor, prefer `get` with the ID returned by `create`.
+Events are returned newest-first. If the response contains `next_cursor`, pass it with `--cursor` to retrieve another page.
 
-## View events
-
-```bash
-parallel-cli monitor events "$MONITOR_ID" --limit 20 --json
-```
-
-Events are returned newest first. If the response has `next_cursor`, pass it with `--cursor` to retrieve another page. To include executions where no material change was detected, add `--include-completions`.
-
-Restrict results to one execution with its event group ID:
+For deeper detail on a specific event group:
 
 ```bash
 parallel-cli monitor events "$MONITOR_ID" --event-group-id "$EVENT_GROUP_ID" --json
 ```
 
-Summarize what changed and when. For `event_stream` events, cite URLs from `output.basis[].citations[].url`. For `snapshot` events, cite URLs from `changed_output.basis[].citations[].url`. Surface `error` events; a `completion` event means the run found no material change.
+Summarize for the user: count of events, then a bulleted list of what changed with timestamps. Cite source URLs from the event payload.
 
-For repeated polling, deduplicate detected changes by stable `event_id`; do not invent a time-based lookback because the GA events endpoint uses cursor pagination.
-
-## Update a monitor
+## Get / update / trigger / cancel
 
 ```bash
+parallel-cli monitor get "$MONITOR_ID" --json
 parallel-cli monitor update "$MONITOR_ID" --frequency 1w --json
-parallel-cli monitor update "$MONITOR_ID" --webhook https://example.com/hook --json
-```
-
-The current CLI exposes updates to frequency, webhook, metadata, and `event_stream` advanced settings. It does not expose query or snapshot Task Run ID updates; create a new monitor to change the tracked target through the CLI.
-
-## Trigger a run now
-
-```bash
 parallel-cli monitor trigger "$MONITOR_ID" --json
-```
-
-`trigger` enqueues a real off-schedule run without changing the regular schedule. Its success response confirms enqueueing, not completion. Retrieve events afterward; a detected event appears only if the run finds a material change. It is not a synthetic webhook test, and cancelled monitors cannot be triggered.
-
-## Cancel a monitor
-
-Cancellation permanently stops future runs. Always confirm with the user immediately before executing:
-
-```bash
 parallel-cli monitor cancel "$MONITOR_ID" --json
 ```
 
-Cancellation is irreversible. Create a new monitor if the user later wants to resume tracking.
+The current CLI does not expose query updates; create a new monitor to change the query.
+
+`trigger` enqueues a real off-schedule run without changing the regular schedule. It is not a synthetic webhook test, and it emits an event only if the run detects a material change.
+
+**Always confirm before cancelling** — cancellation is permanent.
 
 ## Setup
 
-Requires `parallel-cli` installed and authenticated. If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.
+Requires `parallel-cli` (installed and authenticated). If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-monitor
-description: "Continuously track the web for changes on a recurring cadence. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, or delete existing monitors."
+description: "Continuously track the web for changes on a recurring cadence. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, or stop existing monitors, including requests to delete them."
 user-invocable: true
 argument-hint: <create|list|events|get|update|trigger|cancel> [args]
 compatibility: Requires parallel-cli >= 0.4.0 and internet access.

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: parallel-monitor
-description: "Continuously track the web for changes on a recurring cadence. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, or delete existing monitors."
+description: "Continuously track the web for changes on a recurring frequency. Use when the user asks to 'monitor', 'track changes to', 'watch', or 'alert me when' something on the web changes — e.g., 'Track price changes for iPhone 16', 'Alert me when Tesla files a new 8-K', 'Monitor competitor pricing pages weekly'. Also use to list, inspect, update, trigger, or cancel existing monitors and retrieve their events."
 user-invocable: true
-argument-hint: <create|list|events|get|update|simulate|event-group|delete> [args]
-compatibility: Requires parallel-cli >= 0.3.0 and internet access.
+argument-hint: <create|list|events|get|update|trigger|cancel> [args]
+compatibility: Requires parallel-cli >= 0.4.0 and internet access.
 allowed-tools: Bash(parallel-cli:*)
 metadata:
   author: parallel
@@ -13,11 +13,11 @@ metadata:
 
 Action: $ARGUMENTS
 
-> Requires `parallel-cli` ≥ 0.3.0 (the `monitor` command was added in 0.3.0). If `parallel-cli monitor` errors with `no such command` or similar, tell the user to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
+> Requires `parallel-cli` ≥ 0.4.0 for the GA Monitor commands. If a Monitor command or option is missing, tell the user to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
 
 ## What this skill does
 
-Monitors are long-running, server-side jobs that re-check the web on a cadence and emit events when something changes. Unlike search/research/findall (one-shot lookups), monitors persist until deleted and can optionally fire a webhook on each event.
+Monitors are long-running, server-side jobs that check the web on a fixed frequency and emit events when a material change is detected. They persist until cancelled. Events accumulate server-side for polling and can optionally be delivered through a webhook.
 
 ## Decide the action
 
@@ -29,75 +29,96 @@ Parse the user's request and pick one:
 | "What am I monitoring?" / "List monitors" | **list** |
 | "What changed?" / "Show me events for monitor X" | **events** |
 | "Show monitor X" / "Get details for X" | **get** |
-| "Change cadence / query / webhook for X" | **update** |
-| "Test the webhook" / "Fire a test event" | **simulate** (requires a webhook on the monitor) |
-| "Show me the full payload for event group X" | **event-group** |
-| "Stop / delete monitor X" | **delete** (always confirm before deleting) |
+| "Change frequency / webhook / metadata for X" | **update** |
+| "Check monitor X now" / "Run it now" | **trigger** |
+| "Show the events from execution X" | **events** with `--event-group-id` |
+| "Stop / cancel monitor X" | **cancel** (always confirm first) |
 
 ## Create a monitor
 
+Create an `event_stream` monitor for a natural-language query:
+
 ```bash
-parallel-cli monitor create "<query>" --cadence daily --json
+parallel-cli monitor create "<query>" --frequency 1d --json
 ```
 
-Cadence options: `hourly`, `daily` (default), `weekly`, `every_two_weeks`. Match cadence to how often the source actually changes — hourly for prices/news, weekly for filings/staffing.
+Frequency uses `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `6h`, `1d`, or `2w`). The aliases `hourly`, `daily`, `weekly`, and `every_two_weeks` are also accepted. Match the frequency to how often the subject changes.
 
-Optional flags:
+Useful options:
 
-- `--webhook https://example.com/hook` — POST events to a URL as they happen
-- `--metadata '{"team":"competitive-intel"}'` — attach JSON metadata for your own bookkeeping
-- `--output-schema '<json>'` — structure the event payload (advanced)
+- `--processor lite|base` — `lite` is the default; use `base` for harder queries that need greater recall
+- `--webhook https://example.com/hook` — deliver detected events to a webhook
+- `--metadata '{"team":"competitive-intel"}'` — attach bookkeeping metadata
+- `--output-schema '<json>'` — structure `event_stream` event output
+- `--include-backfill` — include a historical sample on the first `event_stream` run
 
-Parse the JSON to extract the `monitor_id`. Tell the user:
-
-- The monitor has been created with its ID
-- The cadence (so they know when to expect first event)
-- That events accumulate server-side — they can run `parallel-cli monitor events $MONITOR_ID` later to see what changed
-
-If they configured a webhook, suggest testing it:
+To monitor changes to an existing Task Run output, create a `snapshot` monitor without a query:
 
 ```bash
-parallel-cli monitor simulate "$MONITOR_ID"
+parallel-cli monitor create --type snapshot --task-run-id trun_abc --frequency 1d --json
 ```
 
-`simulate` requires a webhook to be configured on the monitor. Without one it errors with `Webhook not configured for this monitor` — do not run it on monitors created without `--webhook`.
+Parse the JSON to extract the `monitor_id`. Tell the user the ID, type, frequency, and delivery method. Events can always be retrieved later with `parallel-cli monitor events "$MONITOR_ID" --json`, even without a webhook.
 
-## List monitors
-
-```bash
-parallel-cli monitor list -n 10 --json
-```
-
-Default to `-n 10` — accounts with many historical monitors can return megabytes of JSON otherwise. Raise the limit only if the user explicitly asks for "all" or a larger set. Present as a table: ID, query (truncated), cadence, created.
-
-> Note: `monitor list` is not guaranteed to be sorted newest-first, so a monitor you just created may not appear in the first page of results. If a user is verifying creation, prefer `monitor get $MONITOR_ID` (using the ID returned by create) over scanning the list.
-
-## View events for a monitor
+## List and inspect monitors
 
 ```bash
-parallel-cli monitor events "$MONITOR_ID" --lookback 10d --json
-```
-
-Lookback format: `Nd` (days) or `Nw` (weeks). Default `10d`.
-
-For deeper detail on a specific event group:
-
-```bash
-parallel-cli monitor event-group "$MONITOR_ID" "$EVENT_GROUP_ID" --json
-```
-
-Summarize for the user: count of events in the period, then a bulleted list of what changed with timestamps. Cite source URLs from the event payload.
-
-## Get / update / delete
-
-```bash
+parallel-cli monitor list --limit 10 --json
 parallel-cli monitor get "$MONITOR_ID" --json
-parallel-cli monitor update "$MONITOR_ID" --cadence weekly --json
-parallel-cli monitor delete "$MONITOR_ID" --json
 ```
 
-**Always confirm before deleting** — deletion is permanent.
+`list` returns active monitors newest first by default. Use repeated `--status` flags to include both active and cancelled monitors, and use the returned `next_cursor` for another page:
+
+```bash
+parallel-cli monitor list --status active --status cancelled --limit 10 --json
+parallel-cli monitor list --cursor "$NEXT_CURSOR" --limit 10 --json
+```
+
+Present monitors as a compact table with ID, type, tracked query or Task Run, frequency, and status. When verifying a newly created monitor, prefer `get` with the ID returned by `create`.
+
+## View events
+
+```bash
+parallel-cli monitor events "$MONITOR_ID" --limit 20 --json
+```
+
+Events are returned newest first. If the response has `next_cursor`, pass it with `--cursor` to retrieve another page. To include executions where no material change was detected, add `--include-completions`.
+
+Restrict results to one execution with its event group ID:
+
+```bash
+parallel-cli monitor events "$MONITOR_ID" --event-group-id "$EVENT_GROUP_ID" --json
+```
+
+Summarize what changed and when. Cite URLs from `output.basis[].citations[].url`. For repeated polling, deduplicate detected changes by stable `event_id`; do not invent a time-based lookback because the GA events endpoint uses cursor pagination.
+
+## Update a monitor
+
+```bash
+parallel-cli monitor update "$MONITOR_ID" --frequency 1w --json
+parallel-cli monitor update "$MONITOR_ID" --webhook https://example.com/hook --json
+```
+
+Frequency, webhook, metadata, and `event_stream` advanced settings are mutable. The query and snapshot Task Run ID are immutable; create a new monitor to change either one.
+
+## Trigger a run now
+
+```bash
+parallel-cli monitor trigger "$MONITOR_ID" --json
+```
+
+`trigger` starts a real off-schedule run without changing the regular schedule. It emits a detected event only if a material change is found. It is not a synthetic webhook test, and cancelled monitors cannot be triggered.
+
+## Cancel a monitor
+
+Cancellation permanently stops future runs. Always confirm with the user immediately before executing:
+
+```bash
+parallel-cli monitor cancel "$MONITOR_ID" --json
+```
+
+Cancellation is irreversible. Create a new monitor if the user later wants to resume tracking.
 
 ## Setup
 
-Requires `parallel-cli` (installed and authenticated). If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.
+Requires `parallel-cli` installed and authenticated. If `parallel-cli --version` fails, or if a later command fails with an authentication error, tell the user to see <https://docs.parallel.ai/integrations/cli> and stop.

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -17,7 +17,7 @@ Action: $ARGUMENTS
 
 ## What this skill does
 
-Monitors are long-running, server-side jobs that check the web on a fixed frequency and emit events when a material change is detected. They persist until cancelled. Events accumulate server-side for polling and can optionally be delivered through a webhook.
+Monitors are long-running, server-side jobs that check the web on a fixed frequency and emit events when a material change is detected. They persist until cancelled. Recent events are available server-side for polling and can optionally be delivered through a webhook.
 
 ## Decide the action
 
@@ -58,7 +58,9 @@ To monitor changes to an existing Task Run output, create a `snapshot` monitor w
 parallel-cli monitor create --type snapshot --task-run-id trun_abc --frequency 1d --json
 ```
 
-Parse the JSON to extract the `monitor_id`. Tell the user the ID, type, frequency, and delivery method. Events can always be retrieved later with `parallel-cli monitor events "$MONITOR_ID" --json`, even without a webhook.
+The monitor runs once immediately when created, then continues on its configured schedule. Parse the JSON to extract the `monitor_id`, and tell the user the ID, type, frequency, and delivery method.
+
+Events can be retrieved without a webhook through `parallel-cli monitor events "$MONITOR_ID" --json`, but the API exposes only a bounded recent history. Poll or persist events downstream when durable history matters.
 
 ## List and inspect monitors
 
@@ -90,7 +92,9 @@ Restrict results to one execution with its event group ID:
 parallel-cli monitor events "$MONITOR_ID" --event-group-id "$EVENT_GROUP_ID" --json
 ```
 
-Summarize what changed and when. Cite URLs from `output.basis[].citations[].url`. For repeated polling, deduplicate detected changes by stable `event_id`; do not invent a time-based lookback because the GA events endpoint uses cursor pagination.
+Summarize what changed and when. For `event_stream` events, cite URLs from `output.basis[].citations[].url`. For `snapshot` events, cite URLs from `changed_output.basis[].citations[].url`. Surface `error` events; a `completion` event means the run found no material change.
+
+For repeated polling, deduplicate detected changes by stable `event_id`; do not invent a time-based lookback because the GA events endpoint uses cursor pagination.
 
 ## Update a monitor
 
@@ -99,7 +103,7 @@ parallel-cli monitor update "$MONITOR_ID" --frequency 1w --json
 parallel-cli monitor update "$MONITOR_ID" --webhook https://example.com/hook --json
 ```
 
-Frequency, webhook, metadata, and `event_stream` advanced settings are mutable. The query and snapshot Task Run ID are immutable; create a new monitor to change either one.
+The current CLI exposes updates to frequency, webhook, metadata, and `event_stream` advanced settings. It does not expose query or snapshot Task Run ID updates; create a new monitor to change the tracked target through the CLI.
 
 ## Trigger a run now
 
@@ -107,7 +111,7 @@ Frequency, webhook, metadata, and `event_stream` advanced settings are mutable. 
 parallel-cli monitor trigger "$MONITOR_ID" --json
 ```
 
-`trigger` starts a real off-schedule run without changing the regular schedule. It emits a detected event only if a material change is found. It is not a synthetic webhook test, and cancelled monitors cannot be triggered.
+`trigger` enqueues a real off-schedule run without changing the regular schedule. Its success response confirms enqueueing, not completion. Retrieve events afterward; a detected event appears only if the run finds a material change. It is not a synthetic webhook test, and cancelled monitors cannot be triggered.
 
 ## Cancel a monitor
 

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -13,11 +13,11 @@ metadata:
 
 Action: $ARGUMENTS
 
-> Requires `parallel-cli` ≥ 0.4.0 for the GA Monitor commands. If a Monitor command or option is missing, tell the user to run `parallel-cli update` (or `pipx upgrade parallel-web-tools` if installed via pipx), then retry.
+> Requires `parallel-cli` ≥ 0.4.0 for the GA Monitor commands. If a Monitor command or option is missing, tell the user to update through their installation method (see <https://docs.parallel.ai/integrations/cli>), then retry.
 
 ## What this skill does
 
-Monitors are long-running, server-side jobs that re-check the web on a cadence and emit events when something changes. Unlike search/research/findall (one-shot lookups), monitors persist until cancelled and can optionally fire a webhook on each event.
+Monitors are long-running, server-side jobs that re-check the web on a cadence and emit events when something changes. Unlike search/research/findall (one-shot lookups), monitors persist until cancelled and can optionally deliver detected events through a webhook.
 
 ## Decide the action
 
@@ -44,15 +44,15 @@ Frequency accepts `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `1d`, or 
 
 Optional flags:
 
-- `--webhook https://example.com/hook` — POST events to a URL as they happen
+- `--webhook https://example.com/hook` — deliver detected events to a URL
 - `--metadata '{"team":"competitive-intel"}'` — attach JSON metadata for your own bookkeeping
 - `--output-schema '<json>'` — structure the event payload (advanced)
 
 Parse the JSON to extract the `monitor_id`. Tell the user:
 
 - The monitor has been created with its ID
-- The frequency (so they know when to expect first event)
-- That events accumulate server-side — they can run `parallel-cli monitor events $MONITOR_ID` later to see what changed
+- The frequency (so they know how often the monitor checks)
+- That recent events are available server-side — they can run `parallel-cli monitor events $MONITOR_ID` later to see what changed
 
 ## List monitors
 
@@ -60,7 +60,7 @@ Parse the JSON to extract the `monitor_id`. Tell the user:
 parallel-cli monitor list -n 10 --json
 ```
 
-Default to `-n 10` — accounts with many historical monitors can return megabytes of JSON otherwise. Raise the limit only if the user explicitly asks for "all" or a larger set. Present as a table: ID, query (truncated), frequency, created.
+Default to `-n 10` for concise output. `list` returns active monitors only by default; add `--status active --status cancelled` when the user asks to include cancelled monitors. Raise the limit only for a larger set. Present as a table: ID, query or Task Run (truncated), frequency, created.
 
 > Note: `monitor list` is sorted newest-first. If a user is verifying creation, prefer `monitor get $MONITOR_ID` (using the ID returned by create) over scanning the list.
 
@@ -78,7 +78,7 @@ For deeper detail on a specific event group:
 parallel-cli monitor events "$MONITOR_ID" --event-group-id "$EVENT_GROUP_ID" --json
 ```
 
-Summarize for the user: count of events, then a bulleted list of what changed with timestamps. Cite source URLs from the event payload.
+Summarize for the user: count of events, then a bulleted list of what changed with dates or timestamps. Cite source URLs from the event payload.
 
 ## Get / update / trigger / cancel
 

--- a/skills/parallel-monitor/SKILL.md
+++ b/skills/parallel-monitor/SKILL.md
@@ -29,7 +29,7 @@ Parse the user's request and pick one:
 | "What am I monitoring?" / "List monitors" | **list** |
 | "What changed?" / "Show me events for monitor X" | **events** |
 | "Show monitor X" / "Get details for X" | **get** |
-| "Change cadence / webhook / metadata for X" | **update** |
+| "Change cadence / webhook for X" | **update** |
 | "Check monitor X now" / "Run it now" | **trigger** |
 | "Show me the full payload for event group X" | **events** with `--event-group-id` |
 | "Stop / delete monitor X" | **cancel** (always confirm before cancelling) |
@@ -40,7 +40,7 @@ Parse the user's request and pick one:
 parallel-cli monitor create "<query>" --frequency 1d --json
 ```
 
-Frequency accepts `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `1d`, or `1w`). The aliases `hourly`, `daily`, `weekly`, and `every_two_weeks` are also accepted. Match the cadence to how often the source actually changes — hourly for prices/news, weekly for filings/staffing.
+Frequency accepts `<n><unit>` with `h`, `d`, or `w` (for example `1h`, `1d`, or `1w`). The aliases `hourly`, `daily`, `weekly`, and `every_two_weeks` are also accepted. Match cadence to how often the source actually changes — hourly for prices/news, weekly for filings/staffing.
 
 Optional flags:
 

--- a/tests/test_parallel_monitor_cli_contract.py
+++ b/tests/test_parallel_monitor_cli_contract.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "parallel-monitor" / "SKILL.md"
+
+# This matrix intentionally mirrors the Monitor surface documented by the skill.
+# The tests below also derive commands and flags from SKILL.md so the matrix cannot
+# silently drift away from the documentation it protects.
+MONITOR_CONTRACT: dict[str, tuple[str, ...]] = {
+    "create": ("--frequency", "--webhook", "--metadata", "--output-schema", "--json"),
+    "list": ("-n", "--status", "--json"),
+    "events": ("--cursor", "--event-group-id", "--json"),
+    "get": ("--json",),
+    "update": ("--frequency", "--webhook", "--json"),
+    "trigger": ("--json",),
+    "cancel": ("--json",),
+}
+
+OBSOLETE_COMMANDS = ("simulate", "delete", "event-group")
+OBSOLETE_FLAGS = ("--cadence", "--lookback")
+
+
+class ParallelMonitorCliContractTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.skill_text = SKILL_PATH.read_text(encoding="utf-8")
+        cls.cli_path = shutil.which("parallel-cli")
+        if cls.cli_path is None:
+            raise RuntimeError(
+                "parallel-cli is required for the Monitor contract test; "
+                "install the released parallel-web-tools package"
+            )
+
+        version = cls.run_cli("--version")
+        if version.returncode != 0:
+            raise RuntimeError(
+                "parallel-cli --version failed: "
+                f"{version.stderr.strip() or version.stdout.strip()}"
+            )
+        cls.cli_version = version.stdout.strip()
+
+    @classmethod
+    def run_cli(cls, *args: str) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update({"COLUMNS": "120", "NO_COLOR": "1"})
+        return subprocess.run(
+            [cls.cli_path, *args],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+
+    def assert_cli_succeeded(self, result: subprocess.CompletedProcess[str], invocation: str):
+        self.assertEqual(
+            0,
+            result.returncode,
+            f"{invocation} failed against {self.cli_version}:\n{result.stderr or result.stdout}",
+        )
+
+    def test_documented_commands_exist_in_released_cli(self):
+        argument_hint = re.search(
+            r"^argument-hint:\s*<([^>]+)>",
+            self.skill_text,
+            re.MULTILINE,
+        )
+        self.assertIsNotNone(argument_hint, "parallel-monitor has no command argument-hint")
+        documented_commands = set(argument_hint.group(1).split("|"))
+        expected_commands = set(MONITOR_CONTRACT)
+        self.assertEqual(
+            expected_commands,
+            documented_commands,
+            "argument-hint and Monitor contract matrix disagree",
+        )
+
+        invoked_commands = set(
+            re.findall(r"\bparallel-cli\s+monitor\s+([a-z][a-z-]*)", self.skill_text)
+        )
+        self.assertLessEqual(
+            invoked_commands,
+            expected_commands,
+            "SKILL.md invokes a Monitor command missing from the contract matrix",
+        )
+
+        result = self.run_cli("monitor", "--help")
+        self.assert_cli_succeeded(result, "parallel-cli monitor --help")
+        for command in sorted(expected_commands):
+            with self.subTest(command=command):
+                self.assertRegex(
+                    result.stdout,
+                    rf"(?m)^\s+{re.escape(command)}\s+",
+                    f"{command!r} is documented but missing from {self.cli_version}",
+                )
+
+    def test_documented_flags_exist_under_the_correct_commands(self):
+        monitor_documentation = self.skill_text.partition("## Setup")[0]
+        documented_long_flags = set(re.findall(r"(?<![\w-])--[a-z][a-z-]*", monitor_documentation))
+        expected_long_flags = {
+            flag
+            for flags in MONITOR_CONTRACT.values()
+            for flag in flags
+            if flag.startswith("--")
+        }
+        self.assertEqual(
+            expected_long_flags,
+            documented_long_flags,
+            "documented Monitor flags and contract matrix disagree",
+        )
+
+        for command, flags in MONITOR_CONTRACT.items():
+            result = self.run_cli("monitor", command, "--help")
+            self.assert_cli_succeeded(result, f"parallel-cli monitor {command} --help")
+            for flag in flags:
+                with self.subTest(command=command, flag=flag):
+                    self.assertRegex(
+                        result.stdout,
+                        rf"(?<![\w-]){re.escape(flag)}(?=[\s,=])",
+                        f"{flag!r} is documented for {command!r} but missing from {self.cli_version}",
+                    )
+
+    def test_obsolete_monitor_surface_is_not_documented(self):
+        obsolete_command_pattern = "|".join(map(re.escape, OBSOLETE_COMMANDS))
+        self.assertNotRegex(
+            self.skill_text,
+            rf"\bparallel-cli\s+monitor\s+(?:{obsolete_command_pattern})\b",
+        )
+        self.assertNotRegex(
+            self.skill_text,
+            rf"\*\*(?:{obsolete_command_pattern})\*\*",
+        )
+        for flag in OBSOLETE_FLAGS:
+            with self.subTest(flag=flag):
+                self.assertNotIn(flag, self.skill_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parallel_monitor_cli_contract.py
+++ b/tests/test_parallel_monitor_cli_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import unittest
@@ -12,8 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_PATH = REPO_ROOT / "skills" / "parallel-monitor" / "SKILL.md"
 
 # This matrix intentionally mirrors the Monitor surface documented by the skill.
-# The tests below also derive commands and flags from SKILL.md so the matrix cannot
-# silently drift away from the documentation it protects.
+# The tests derive its command and flag inventory from SKILL.md and validate each
+# concrete invocation against the mapping below.
 MONITOR_CONTRACT: dict[str, tuple[str, ...]] = {
     "create": ("--frequency", "--webhook", "--metadata", "--output-schema", "--json"),
     "list": ("-n", "--status", "--json"),
@@ -26,6 +27,17 @@ MONITOR_CONTRACT: dict[str, tuple[str, ...]] = {
 
 OBSOLETE_COMMANDS = ("simulate", "delete", "event-group")
 OBSOLETE_FLAGS = ("--cadence", "--lookback")
+
+
+def documented_monitor_invocations(skill_text: str) -> list[tuple[str, tuple[str, ...], str]]:
+    invocations: list[tuple[str, tuple[str, ...], str]] = []
+    for match in re.finditer(r"(?m)(?:^|`)(parallel-cli monitor [^`\n]+)", skill_text):
+        invocation = match.group(1).strip()
+        tokens = shlex.split(invocation)
+        command = tokens[2]
+        flags = tuple(token.split("=", 1)[0] for token in tokens[3:] if token.startswith("-"))
+        invocations.append((command, flags, invocation))
+    return invocations
 
 
 class ParallelMonitorCliContractTestCase(unittest.TestCase):
@@ -81,9 +93,9 @@ class ParallelMonitorCliContractTestCase(unittest.TestCase):
             "argument-hint and Monitor contract matrix disagree",
         )
 
-        invoked_commands = set(
-            re.findall(r"\bparallel-cli\s+monitor\s+([a-z][a-z-]*)", self.skill_text)
-        )
+        invocations = documented_monitor_invocations(self.skill_text)
+        self.assertTrue(invocations, "parallel-monitor has no concrete CLI examples")
+        invoked_commands = {command for command, _, _ in invocations}
         self.assertLessEqual(
             invoked_commands,
             expected_commands,
@@ -115,6 +127,20 @@ class ParallelMonitorCliContractTestCase(unittest.TestCase):
             "documented Monitor flags and contract matrix disagree",
         )
 
+        for command, flags, invocation in documented_monitor_invocations(self.skill_text):
+            with self.subTest(invocation=invocation):
+                self.assertIn(
+                    command,
+                    MONITOR_CONTRACT,
+                    f"{invocation!r} uses a command missing from the contract matrix",
+                )
+                undocumented_for_command = set(flags) - set(MONITOR_CONTRACT[command])
+                self.assertFalse(
+                    undocumented_for_command,
+                    f"{invocation!r} assigns flags to the wrong Monitor command: "
+                    f"{sorted(undocumented_for_command)}",
+                )
+
         for command, flags in MONITOR_CONTRACT.items():
             result = self.run_cli("monitor", command, "--help")
             self.assert_cli_succeeded(result, f"parallel-cli monitor {command} --help")
@@ -135,6 +161,10 @@ class ParallelMonitorCliContractTestCase(unittest.TestCase):
         self.assertNotRegex(
             self.skill_text,
             rf"\*\*(?:{obsolete_command_pattern})\*\*",
+        )
+        self.assertNotRegex(
+            self.skill_text,
+            rf"`monitor\s+(?:{obsolete_command_pattern})\b",
         )
         for flag in OBSOLETE_FLAGS:
             with self.subTest(flag=flag):

--- a/tests/test_parallel_monitor_cli_contract.py
+++ b/tests/test_parallel_monitor_cli_contract.py
@@ -13,8 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SKILL_PATH = REPO_ROOT / "skills" / "parallel-monitor" / "SKILL.md"
 
 # This matrix intentionally mirrors the Monitor surface documented by the skill.
-# The tests derive its command and flag inventory from SKILL.md and validate each
-# concrete invocation against the mapping below.
+# The tests derive its command and flag inventory from SKILL.md and validate its
+# command sections and concrete invocations against the mapping below.
 MONITOR_CONTRACT: dict[str, tuple[str, ...]] = {
     "create": ("--frequency", "--webhook", "--metadata", "--output-schema", "--json"),
     "list": ("-n", "--status", "--json"),
@@ -27,6 +27,30 @@ MONITOR_CONTRACT: dict[str, tuple[str, ...]] = {
 
 OBSOLETE_COMMANDS = ("simulate", "delete", "event-group")
 OBSOLETE_FLAGS = ("--cadence", "--lookback")
+
+
+def documented_flags(text: str) -> set[str]:
+    long_flags = re.findall(r"(?<![\w-])--[a-z][a-z-]*", text)
+    short_flags = re.findall(r"(?<![\w-])-[a-z](?=[\s,])", text)
+    return set(long_flags) | set(short_flags)
+
+
+def documented_command_sections(skill_text: str) -> list[tuple[str, tuple[str, ...], str]]:
+    sections: list[tuple[str, tuple[str, ...], str]] = []
+    headings = list(re.finditer(r"(?m)^##\s+(.+)$", skill_text))
+    for index, heading_match in enumerate(headings):
+        heading = heading_match.group(1).strip()
+        commands = tuple(
+            command
+            for command in MONITOR_CONTRACT
+            if re.search(rf"\b{re.escape(command)}\b", heading, re.IGNORECASE)
+        )
+        if not commands:
+            continue
+
+        section_end = headings[index + 1].start() if index + 1 < len(headings) else len(skill_text)
+        sections.append((heading, commands, skill_text[heading_match.end() : section_end]))
+    return sections
 
 
 def documented_monitor_invocations(skill_text: str) -> list[tuple[str, tuple[str, ...], str]]:
@@ -114,18 +138,27 @@ class ParallelMonitorCliContractTestCase(unittest.TestCase):
 
     def test_documented_flags_exist_under_the_correct_commands(self):
         monitor_documentation = self.skill_text.partition("## Setup")[0]
-        documented_long_flags = set(re.findall(r"(?<![\w-])--[a-z][a-z-]*", monitor_documentation))
-        expected_long_flags = {
-            flag
-            for flags in MONITOR_CONTRACT.values()
-            for flag in flags
-            if flag.startswith("--")
-        }
+        actual_flags = documented_flags(monitor_documentation)
+        expected_flags = {flag for flags in MONITOR_CONTRACT.values() for flag in flags}
         self.assertEqual(
-            expected_long_flags,
-            documented_long_flags,
+            expected_flags,
+            actual_flags,
             "documented Monitor flags and contract matrix disagree",
         )
+
+        for heading, commands, section_text in documented_command_sections(self.skill_text):
+            allowed_flags = {
+                flag
+                for command in commands
+                for flag in MONITOR_CONTRACT[command]
+            }
+            unexpected_flags = documented_flags(section_text) - allowed_flags
+            with self.subTest(section=heading):
+                self.assertFalse(
+                    unexpected_flags,
+                    f"{heading!r} documents flags for the wrong Monitor command: "
+                    f"{sorted(unexpected_flags)}",
+                )
 
         for command, flags, invocation in documented_monitor_invocations(self.skill_text):
             with self.subTest(invocation=invocation):


### PR DESCRIPTION
## Summary

- update the existing `parallel-monitor` skill from the alpha Monitor CLI to the GA command surface
- replace removed commands and options with `--frequency`, `trigger`, `events --event-group-id`, `cancel`, and cursor-based event retrieval
- correct list, webhook, event-history, update, and installer guidance while preserving the skill's existing structure and scope
- add a focused CI contract test that checks the skill's documented Monitor commands and flags against the latest released CLI using `--help`

## Why

The skill still targeted the pre-GA Monitor interface. Commands and options including `--cadence`, `simulate`, `event-group`, `delete`, and `--lookback` no longer exist in current `parallel-cli` releases.

This keeps the original skill intact and changes only the stale command surface and behavior that is no longer true.

A source-level review found that a few alpha-era operational assumptions remained after the command migration: update instructions were standalone-specific, frequency was conflated with event timing, list guidance assumed historical monitors were returned by default, and webhook/event wording did not match the GA response model. Those statements now follow the released CLI implementation and API contract.

The new contract test installs the latest stable `parallel-web-tools` release in CI, verifies only the Monitor commands and flags documented by this skill, and rejects obsolete command invocations without treating natural-language requests such as "delete this monitor" as CLI commands.

## Validation

- checked every documented Monitor command and option against `parallel-cli` 0.7.1 help output, source, and tests
- focused Monitor CLI contract test (3 tests)
- `pre-commit run --all-files`
- `python3 -m unittest discover -s tests` (27 tests)
- `pnpm typecheck`
- `pnpm build`
- `pnpm run build:archives -- --version 0.7.0 --output release-assets`
