### PR TITLE
Add Parallel memory skill for CLI 0.8.1

### DIFF
--- a/.agents/skills/parallel-memory
+++ b/.agents/skills/parallel-memory
@@ -1,0 +1,1 @@
+../../skills/parallel-memory/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Skills follow the [Agent Skills](https://agentskills.io/specification) specifica
 | **parallel-data-enrichment** | Enrich lists of companies, people, products               |
 | **parallel-findall**         | Discover entities matching a natural-language description |
 | **parallel-monitor**         | Continuously track the web for changes (with webhooks)    |
+| **parallel-memory**          | Recall and manage saved Parallel runs                     |
 | **migrate-to-parallel**      | Migrate Exa, Tavily, Perplexity, or Firecrawl integrations to Parallel |
 | **parallel-cli-setup**       | Install/update CLI, authenticate, and handle balance      |
 | **status**                   | Check running research task status                        |
@@ -85,6 +86,7 @@ Skills follow the [Agent Skills](https://agentskills.io/specification) specifica
 /parallel:parallel-data-enrichment Apple, Microsoft, Google - get CEO names
 /parallel:parallel-findall AI startups that raised Series A in 2026
 /parallel:parallel-monitor track price changes for the iPhone 16 Pro
+/parallel:parallel-memory retrieve past research about AI code assistants
 /parallel:migrate-to-parallel migrate this app from Tavily to Parallel
 /parallel:migrate-to-parallel migrate this app from Perplexity to Parallel
 /parallel:migrate-to-parallel migrate this app from Firecrawl to Parallel

--- a/skills/parallel-cli-setup/SKILL.md
+++ b/skills/parallel-cli-setup/SKILL.md
@@ -26,7 +26,7 @@ If missing, install with any of these methods:
 3. Linux/macOS/Windows (npm): `npm install -g parallel-web-cli`
 4. Linux/macOS/Windows (pipx): `pipx install "parallel-web-tools[cli]" && pipx ensurepath`
 
-When `parallel-cli` is present, require version `>=0.7.1`. If older, identify the install method before advising an update. Use `command -v parallel-cli`, then inspect `readlink "$(command -v parallel-cli)"` if it is a symlink. Paths under `~/.local/share/uv/
+When `parallel-cli` is present, require version `>=0.8.1`. If older, identify the install method before advising an update. Use `command -v parallel-cli`, then inspect `readlink "$(command -v parallel-cli)"` if it is a symlink. Paths under `~/.local/share/uv/
   tools/` indicate `uv tool install`; paths under `~/.local/share/parallel-cli/` indicate the standalone installer.
 
 Upgrade commands (choose based on how it was installed):

--- a/skills/parallel-memory/SKILL.md
+++ b/skills/parallel-memory/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: parallel-memory
+description: "Recall past Parallel Task, Monitor, and FindAll runs when they may help; evict runs or clear memory when asked."
+user-invocable: true
+argument-hint: <retrieve|evict|clear> [args]
+compatibility: Requires parallel-cli with memory support and internet access.
+allowed-tools: Bash(parallel-cli:*)
+metadata:
+  author: parallel
+---
+
+# Parallel Memory
+
+Action: $ARGUMENTS
+
+> Requires `parallel-cli` with memory commands. If `parallel-cli memory --help` fails with `no such command` or similar, tell the user to update `parallel-cli`, then retry.
+
+## When to use
+
+- Inspect memory only when prior Parallel work may help fulfill the request or the user asks to retrieve, evict, or clear it.
+- Memory results are excerpts from past runs; fetch the source run for full records, and launch a fresh run for time-sensitive claims.
+
+## Choose the operation
+
+| User intent | Operation |
+|---|---|
+| Recall prior work about a topic | Retrieve with a concise query |
+| Show recent past runs | Retrieve without `query` |
+| Remove one saved Task, Monitor, or FindAll source | Evict by exact `kind` and `id` |
+| Permanently remove every saved entry | Clear memory |
+| Turn memory off | Direct the user to account settings; do not clear as a substitute |
+
+## Use the CLI
+
+Use `parallel-cli memory` for retrieve, evict, and clear operations.
+
+- If memory is not eligible, report the returned reason; it distinguishes rollout, organization settings, account opt-in, and key eligibility.
+- On a key-eligibility error, tell the user to reauthenticate.
+
+## Retrieve memory
+
+Form a short semantic query that describes the prior work to find. Apply filters when they help. Empty `results` is a successful retrieval with no matches, not an error.
+
+- Set `kind` to `task`, `monitor`, or `findall` when it clearly narrows the retrieval.
+- Set `since` for an explicit timestamp boundary (RFC 3339, e.g. `2026-08-01T00:00:00Z`).
+- Omit `query` when retrieving recent memories rather than a topic.
+
+Retrieve by query:
+
+```bash
+parallel-cli memory retrieve \
+  --query "serverless inference vendors"
+```
+
+For recent memories:
+
+```bash
+parallel-cli memory retrieve \
+  --limit 5
+```
+
+## Use results
+
+Handle each result by its `kind`:
+
+- `task`: use `id`, `updated_at`, `input_excerpt`, and `output_excerpt`.
+- `monitor`: use the monitor `id`, status, query excerpt, and matching event IDs, timestamps, and excerpts.
+- `findall`: use `id`, `updated_at`, objective excerpt, and `matched_count`.
+
+* Fetch the original Task result, Monitor events, or FindAll result when exact output, entities, citations, or provenance matter.
+* Summarize the useful findings and unresolved questions.
+* Lead with what the prior work established, then list the contributing saved runs with kind, ID, and timestamp.
+* Distinguish recalled information from any fresh verification.
+* If launching a new run and the recalled context is helpful, put it explicitly into the new run input; retrieval does not inject memory automatically.
+
+Expect ingestion to be asynchronous. Do not promise that a newly completed run will be immediately retrievable.
+
+## Evict or clear memory
+
+Evict a single run from memory, or clear all memory entries. These do not delete the underlying Parallel runs. Ask for confirmation before clearing unless the user already asked for it.
+
+```bash
+parallel-cli memory evict \
+  --kind task \
+  --id "trun_example"
+```
+
+```bash
+parallel-cli memory clear \
+  --confirm-clear
+```

--- a/skills/parallel-memory/SKILL.md
+++ b/skills/parallel-memory/SKILL.md
@@ -61,7 +61,7 @@ parallel-cli memory retrieve \
 
 ## Use results
 
-Handle each result by its `kind`:
+Available fields vary by `kind`:
 
 - `task`: use `id`, `updated_at`, `input_excerpt`, and `output_excerpt`.
 - `monitor`: use the monitor `id`, status, query excerpt, and matching event IDs, timestamps, and excerpts.
@@ -71,7 +71,7 @@ Handle each result by its `kind`:
 - Summarize the useful findings and unresolved questions.
 - Lead with what the prior work established, then list the contributing saved runs with kind, ID, and timestamp.
 - Distinguish recalled information from any fresh verification.
-- If launching a new run and the recalled context is helpful, put it explicitly into the new run input; retrieval does not inject memory automatically.
+- Parallel runs do not consult Memory. If recalled information may be useful, include the relevant details in the new run's input.
 
 Expect ingestion to be asynchronous. Do not promise that a newly completed run will be immediately retrievable.
 

--- a/skills/parallel-memory/SKILL.md
+++ b/skills/parallel-memory/SKILL.md
@@ -27,7 +27,7 @@ Action: $ARGUMENTS
 | Recall prior work about a topic | Retrieve with a concise query |
 | Show recent past runs | Retrieve without `query` |
 | Remove one saved Task, Monitor, or FindAll source | Evict by exact `kind` and `id` |
-| Permanently remove every saved entry | Clear memory |
+| Permanently remove all entries from your personal Memory | Clear memory |
 | Turn memory off | Direct the user to account settings; do not clear as a substitute |
 
 ## Use the CLI
@@ -77,7 +77,7 @@ Expect ingestion to be asynchronous. Do not promise that a newly completed run w
 
 ## Evict or clear memory
 
-Evict a single run from memory, or clear all memory entries. These do not delete the underlying Parallel runs. Ask for confirmation before clearing unless the user already asked for it.
+Evict a single run from your personal Memory, or clear it entirely. These do not delete the underlying Parallel runs. Ask for confirmation before clearing unless the user already asked for it.
 
 ```bash
 parallel-cli memory evict \

--- a/skills/parallel-memory/SKILL.md
+++ b/skills/parallel-memory/SKILL.md
@@ -18,7 +18,7 @@ Action: $ARGUMENTS
 ## When to use
 
 - Inspect memory only when prior Parallel work may help fulfill the request or the user asks to retrieve, evict, or clear it.
-- Memory results are excerpts from past runs; fetch the source run for full records, and launch a fresh run for time-sensitive claims.
+- Memory results are excerpts from past runs; fetch the source run for full records, and launch a fresh run when current information is required.
 
 ## Choose the operation
 

--- a/skills/parallel-memory/SKILL.md
+++ b/skills/parallel-memory/SKILL.md
@@ -3,7 +3,7 @@ name: parallel-memory
 description: "Recall past Parallel Task, Monitor, and FindAll runs when they may help; evict runs or clear memory when asked."
 user-invocable: true
 argument-hint: <retrieve|evict|clear> [args]
-compatibility: Requires parallel-cli with memory support and internet access.
+compatibility: Requires parallel-cli >=0.8.1 and internet access.
 allowed-tools: Bash(parallel-cli:*)
 metadata:
   author: parallel
@@ -13,7 +13,7 @@ metadata:
 
 Action: $ARGUMENTS
 
-> Requires `parallel-cli` with memory commands. If `parallel-cli memory --help` fails with `no such command` or similar, tell the user to update `parallel-cli`, then retry.
+> Requires `parallel-cli >=0.8.1`. If the installed version is older, or `parallel-cli memory --help` fails with `no such command` or similar, tell the user to update `parallel-cli`, then retry.
 
 ## When to use
 
@@ -67,11 +67,11 @@ Handle each result by its `kind`:
 - `monitor`: use the monitor `id`, status, query excerpt, and matching event IDs, timestamps, and excerpts.
 - `findall`: use `id`, `updated_at`, objective excerpt, and `matched_count`.
 
-* Fetch the original Task result, Monitor events, or FindAll result when exact output, entities, citations, or provenance matter.
-* Summarize the useful findings and unresolved questions.
-* Lead with what the prior work established, then list the contributing saved runs with kind, ID, and timestamp.
-* Distinguish recalled information from any fresh verification.
-* If launching a new run and the recalled context is helpful, put it explicitly into the new run input; retrieval does not inject memory automatically.
+- Fetch the original Task result, Monitor events, or FindAll result when exact output, entities, citations, or provenance matter.
+- Summarize the useful findings and unresolved questions.
+- Lead with what the prior work established, then list the contributing saved runs with kind, ID, and timestamp.
+- Distinguish recalled information from any fresh verification.
+- If launching a new run and the recalled context is helpful, put it explicitly into the new run input; retrieval does not inject memory automatically.
 
 Expect ingestion to be asynchronous. Do not promise that a newly completed run will be immediately retrievable.
 

--- a/skills/parallel-memory/agents/openai.yaml
+++ b/skills/parallel-memory/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Parallel Memory"
-  short_description: "Recall past Parallel runs"
-  default_prompt: "Use $parallel-memory to retrieve and reuse my past Parallel runs about this topic."

--- a/skills/parallel-memory/agents/openai.yaml
+++ b/skills/parallel-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Parallel Memory"
+  short_description: "Recall past Parallel runs"
+  default_prompt: "Use $parallel-memory to retrieve and reuse my past Parallel runs about this topic."

--- a/tests/test_repository_layout.py
+++ b/tests/test_repository_layout.py
@@ -41,6 +41,12 @@ class RepositoryLayoutTestCase(unittest.TestCase):
         self.assertTrue(link.is_symlink())
         self.assertTrue(link.exists())
 
+    def test_memory_skill_is_project_discoverable(self):
+        link = PROJECT_SKILLS_ROOT / "parallel-memory"
+
+        self.assertTrue(link.is_symlink())
+        self.assertTrue(link.exists())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- add the `parallel-memory` skill for retrieving, evicting, and clearing saved Parallel runs
- require `parallel-cli >=0.8.1` in both the memory skill and CLI setup flow